### PR TITLE
improved ignoreregex

### DIFF
--- a/docs/unsupported_scripts.md
+++ b/docs/unsupported_scripts.md
@@ -19,7 +19,7 @@ Set Tactical fail2ban filter conf file
 tacticalfail2banfilter="$(cat << EOF
 [Definition]
 failregex = ^<HOST>.*400.17.*$
-ignoreregex = ^<HOST>.*200.*$
+ignoreregex = ^<HOST>.*200.\d+.*$
 EOF
 )"
 sudo echo "${tacticalfail2banfilter}" > /etc/fail2ban/filter.d/tacticalrmm.conf


### PR DESCRIPTION
Change the regex to not match every 200 in the log, i.e. i had a device with "200" in its name, which triggered the ignoreregex resulting in not being banned.