### PR TITLE
fix domain-resolver.sh

### DIFF
--- a/docs/unsupported_scripts.md
+++ b/docs/unsupported_scripts.md
@@ -460,7 +460,7 @@ Create a bash script domain-resolver.sh which does the DNS lookups for you:
     do
         ddns_record="$line"
         if [[ !  -z  $ddns_record ]]; then
-            resolved_ip=getent ahosts $line | awk '{ print $1 ; exit }'
+            resolved_ip=$( getent ahosts $line | awk '{ print $1 ; exit }' )
             if [[ !  -z  $resolved_ip ]]; then
                 echo "allow $resolved_ip;# from $ddns_record"
             fi


### PR DESCRIPTION
added a $( ) around the "getent" command so it will be executed correctly and does not give a error.