### PR TITLE
Update docker docs to remove sudo

### DIFF
--- a/docs/install_docker.md
+++ b/docs/install_docker.md
@@ -8,6 +8,8 @@
 
 Install docker.
 
+Please keep in mind that the docker package is usually called docker.io in debian based distros including ubuntu
+
 ### Create the DNS A records
 
 !!!warning

--- a/docs/install_docker.md
+++ b/docs/install_docker.md
@@ -102,10 +102,16 @@ echo "CERT_PRIV_KEY=$(sudo base64 -w 0 /path/to/priv/key)" >> .env
 Run the below command to start the environment:
 
 ```bash
-sudo docker compose up -d
+docker compose up -d
 ```
 
 Removing the -d will start the containers in the foreground and is useful for debugging.
+
+If you get a error saying you don't have permission you can add yourself to the docker group with:
+```
+sudo usermod -aG docker [user]
+```
+You may need to log out and back in for it to take full effect.
 
 ### Login
 

--- a/docs/update_docker.md
+++ b/docs/update_docker.md
@@ -7,16 +7,24 @@
 
 Tactical RMM updates the docker images on every release and should be available within a few minutes.
 
-SSH into your server as a root user and run the below commands:
+SSH into your server as a user that is in the docker group and run the below commands:
 
 ```bash
 cd [dir/with/compose/file]
 mv docker-compose.yml docker-compose.yml.old
 wget https://raw.githubusercontent.com/amidaware/tacticalrmm/master/docker/docker-compose.yml
-sudo docker-compose pull
-sudo docker-compose down
-sudo docker-compose up -d --remove-orphans
+docker-compose pull
+docker-compose down
+docker-compose up -d --remove-orphans
 ```
+
+If your user isn't in the docker group you can add yourself to the group with:
+
+```
+sudo usermod -aG docker [user]
+```
+Keep in mind that you will most likely need to log out and then back in
+
 
 ## Keeping your Let's Encrypt certificate up to date
 
@@ -36,6 +44,6 @@ echo "CERT_PRIV_KEY=$(sudo base64 -w 0 /etc/letsencrypt/live/${rootdomain}/privk
 !!!warning
     You must remove the old and any duplicate entries for CERT_PUB_KEY and CERT_PRIV_KEY in the .env file.
 
-Now run `sudo docker compose up -d restart` and the new certificate will be in effect.
+Now run `docker compose up -d restart` and the new certificate will be in effect.
 
 Bonus: [Upgrade postgres13 to 14](https://github.com/amidaware/trmm-awesome#docker-upgrade-postgres-13-to-14)

--- a/docs/update_docker.md
+++ b/docs/update_docker.md
@@ -13,9 +13,9 @@ SSH into your server as a root user and run the below commands:
 cd [dir/with/compose/file]
 mv docker-compose.yml docker-compose.yml.old
 wget https://raw.githubusercontent.com/amidaware/tacticalrmm/master/docker/docker-compose.yml
-sudo docker compose pull
-sudo docker compose down
-sudo docker compose up -d --remove-orphans
+sudo docker-compose pull
+sudo docker-compose down
+sudo docker-compose up -d --remove-orphans
 ```
 
 ## Keeping your Let's Encrypt certificate up to date


### PR DESCRIPTION
I noticed that the docker install and update docs suggested using docker as root. This is a security risk and is unnecessarily complicated. The better alternative is to add your user into the docker group. This allows for easy access to docker commands without having to deal with sudo or passwords.

I also added a bit of clarification for installing docker.