### PR TITLE
Updating text re. Apple Silicon Processors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ It uses an [agent](https://github.com/amidaware/rmmagent) written in Golang and 
 
 ## Mac agent versions supported
 
-- 64 bit Intel and Apple Silicon (M1, M2)
+- 64 bit Intel and Apple Silicon (M-Series Processors)
 
 ## Discuss/Collaborate and Get Help/Support
 


### PR DESCRIPTION
Less need to keep updating docs every year with each M{x} version that comes out. Seems M1, M2, and M3 are supported, so might as well say "M-Series Processors" instead of listing them individually.